### PR TITLE
build(pom): add JaCoCo report at verify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
+    <argLine></argLine>
   </properties>
 
   <dependencyManagement>
@@ -181,20 +182,43 @@
             <artifactId>doxia-module-markdown</artifactId>
             <version>2.0.0</version> 
         </plugin>
-  
-	    
-	    
+
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.14</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <!-- Generate the HTML/XML/CSV report in target/site/jacoco at verify -->
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
         <redirectTestOutputToFile>false</redirectTestOutputToFile>
-          <forkCount>0</forkCount>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
           <excludedGroups>exclude</excludedGroups>
           <excludes>
             <exclude>**/commandline/ConfigInitializerTest.java</exclude>
           </excludes>
+          <argLine>@{argLine}</argLine>
         </configuration>
       </plugin>
       


### PR DESCRIPTION
- add jacoco-maven-plugin (prepare-agent, report@verify)

% FOOTER %
type-of: build

closes: https://esg-yorku-team.atlassian.net/browse/CE-37
closes-desc: "Add JaCoCo support. Run JaCoCo report with `mvn verify`"