### PR TITLE
docs(attributions): add YAML frontmatter for doc authorship

### DIFF
--- a/src/site/markdown/contributors/commits.md
+++ b/src/site/markdown/contributors/commits.md
@@ -1,3 +1,12 @@
+---
+main_authors: ["Nina Dang <nina2022@my.yorku.ca>"]
+
+contributors: ["Sotirios Liaskos <liaskos@yorku.ca>"]
+
+reviewers: [""]
+
+---
+
 # Commit Conventions and Principles
 
 ## Principles

--- a/src/site/markdown/contributors/deploy.md
+++ b/src/site/markdown/contributors/deploy.md
@@ -1,3 +1,11 @@
+---
+main_authors: ["Nina Dang <nina2022@my.yorku.ca>"]
+
+contributors: [""]
+
+reviewers: [""]
+
+---
 
 # Deployment Workflow
 

--- a/src/site/markdown/contributors/git-habits.md
+++ b/src/site/markdown/contributors/git-habits.md
@@ -1,3 +1,12 @@
+---
+main_authors: ["Nina Dang <nina2022@my.yorku.ca>"]
+
+contributors: [""]
+
+reviewers: ["Sotirios Liaskos <liaskos@yorku.ca>"]
+
+---
+
 # Good Git and Commit Habits
 
 <!-- TOC -->

--- a/src/site/markdown/contributors/release.md
+++ b/src/site/markdown/contributors/release.md
@@ -1,3 +1,12 @@
+---
+main_authors: ["Nina Dang <nina2022@my.yorku.ca>"]
+
+contributors: [""]
+
+reviewers: ["Sotirios Liaskos <liaskos@yorku.ca>"]
+
+---
+
 # Release Workflow
 ### *(under construction)*
 \[ concrete `mvn` and `git` steps to produce the next release. Separate from deployment. \]


### PR DESCRIPTION
- Add main_authors, contributors, and reviewers metadata to Markdown files
- Show authorship as `<meta>` tags in the site’s `<head>` after `mvn clean site`

% FOOTER %
type-of: docs

closes: https://esg-yorku-team.atlassian.net/browse/CE-73
closes-desc: "Documentation: attributions"